### PR TITLE
Update Require extension hooks babel from beta to 1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11596,13 +11596,13 @@
       }
     },
     "require-extension-hooks-babel": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/require-extension-hooks-babel/-/require-extension-hooks-babel-1.0.0-beta.1.tgz",
-      "integrity": "sha512-UGWhOGc8agkbS/VLACPycl72sPo6Es0ajYDOQhzhM/xW704A+JIT7To9zt0aDqBAi77rmaFb9tIYuy3iKLCk7A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/require-extension-hooks-babel/-/require-extension-hooks-babel-1.0.0.tgz",
+      "integrity": "sha512-n8+KxBVMjUgNz3ipFOrGoflWgiabcoGul8PE+5JZk1oA3/Bb5jtCvne/sRZ4TjkFuqDDOiWxPfAVK/UsL0iMOw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.0.0-beta.51",
-        "@babel/preset-env": "^7.0.0-beta.51"
+        "@babel/core": "^7.4.4",
+        "@babel/preset-env": "^7.4.4"
       }
     },
     "require-extension-hooks-vue": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nyc": "^13.3.0",
     "prettier": "^1.16.4",
     "require-extension-hooks": "^0.3.3",
-    "require-extension-hooks-babel": "^1.0.0-beta.1",
+    "require-extension-hooks-babel": "^1.0.0",
     "require-extension-hooks-vue": "^2.0.0"
   }
 }


### PR DESCRIPTION
- [x] Update [`require-extension-hooks-babel`](https://github.com/jackmellis/require-extension-hooks-babel/pull/8)